### PR TITLE
注文情報確認画面のレイアウト修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
-  
+
   def autheniticate_customer
     if current_customer==nil
       flash[:notice]="ログインが必要です"

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
 
   <div class="col-12  mt-5">
-    <h5 class="d-inline col-3 text-center" style="background-color: #EEEEEE">ショッピングカート</h5>
+    <h5 class="d-inline col-3 text-center bg-light">ショッピングカート</h5>
     <%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, class: 'btn btn-danger offset-7'%>
   </div>
 
@@ -53,7 +53,7 @@
 
     </div>
 
-    <div class="col12 mt-5 mx-auto">
+    <div class="mt-5 mx-auto">
       <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success text-center" %>
     </div>
   </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,15 +1,19 @@
   <div class="container">
 
     <div class="row">
-      <h1>注文情報確認</h1>
-      <table class="table table-hover table-inverse">
+      <div class="col-3 mt-5">
+        <h5 class="text-center bg-light">注文情報確認</h5>
+      </div>
+    </div>
+    
+    <div class="row">
+      <table class="col-7 mr-5 mt-3 table table-bordered">
         <thead>
           <tr class="bg-light">
             <th>商品名</th>
             <th>単価(税込)</th>
             <th>数量</th>
             <th>小計</th>
-            <th colspan="4"></th>
           </tr>
         </thead>
         <tbody>
@@ -20,17 +24,15 @@
                 <%= cart_item.item.item_name %>
               </td>
               <td><%= cart_item.item.add_tax_price.to_s(:delimited) %></td>
-              <td>
-                <%= cart_item.amount %>
-
-              </td>
+              <td><%= cart_item.amount %> </td>
               <td><%= cart_item.subtotal.to_s(:delimited) %></td>
-              <td><% @sum += cart_item.subtotal %></td>
+              <% @sum += cart_item.subtotal %>
             </tr>
           <% end %>
         </tbody>
       </table>
-       <table class="table row justify-content-end">
+      
+      <table class="col-3 ml-5 mt-3 table table-bordered">
         <tr>
           <th class="bg-light">送料</th>
           <td><%= @order.postage.to_s %></td>
@@ -45,29 +47,29 @@
           <td><%= @sum.to_s(:delimited) %></td>
         </tr>
       </table>
-      </div>
-      <div class="row">
-        <h4>支払方法</h4>
-        <%= @order.payment_method %>
-      </div>
-      <div class="row">
-        <h4>お届け先</h4>
-        〒<%= @order.shipping_post_code %>
-        <%= @order.shipping_address %>
-        <%= @order.shipping_name %>
-      </div>
+    </div>
+      
+    <div class="row mt-3">
+      <label class="mr-5 font-weight-bold">支払方法</label>
+      <%= @order.payment_method %>
+    </div>
+    <div class="row mt-3">
+     <label class="mr-5 font-weight-bold">お届け先</label>
+      〒<%= @order.shipping_post_code %>
+      <%= @order.shipping_address %><br>
+      <%= @order.shipping_name %>
+    </div>
 
+    <%= form_with(model: @order,url: orders_path,method: :post, local: true, class: "mt-5 col-12 text-center")do |f| %>
+      <%= f.hidden_field :postage, :value => @order.postage %>
+      <%= f.hidden_field :billing_amount, :value => @sum.to_s %>
+      <%= f.hidden_field :payment_method, :value => @order.payment_method %>
+      <%= f.hidden_field :shipping_post_code, :value => @order.shipping_post_code %>
+      <%= f.hidden_field :shipping_address, :value => @order.shipping_address %>
+      <%= f.hidden_field :shipping_name, :value => @order.shipping_name %>
+      <%= f.hidden_field :order_status, :value => "入金待ち" %>
+      <%= f.submit "注文を確定する", class: "btn btn-success" %>
+    <% end %>
 
-<%= form_with(model: @order,url: orders_path,method: :post, local: true)do |f| %>
-  <%= f.hidden_field :postage, :value => @order.postage %>
-  <%= f.hidden_field :billing_amount, :value => @sum.to_s %>
-  <%= f.hidden_field :payment_method, :value => @order.payment_method %>
-  <%= f.hidden_field :shipping_post_code, :value => @order.shipping_post_code %>
-  <%= f.hidden_field :shipping_address, :value => @order.shipping_address %>
-  <%= f.hidden_field :shipping_name, :value => @order.shipping_name %>
-  <%= f.hidden_field :order_status, :value => "入金待ち" %>
-  <%= f.submit "注文を確定" %>
-<% end %>
-</div>
 </div>
 


### PR DESCRIPTION
注文情報確認画面のレイアウトを修正しました。
レイアウトに統一感を持たせるために、一部カート内一覧画面のレイアウトを修正しました。